### PR TITLE
Use release-20.03 bootstrap instead of bleeding edge

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -52,7 +52,7 @@ import java.util.zip.ZipInputStream;
  */
 final class TermuxInstaller {
 
-    static String defaultBootstrapURL = "https://nix-on-droid.unboiled.info/bootstrap";
+    static String defaultBootstrapURL = "https://nix-on-droid.unboiled.info/bootstrap-release-20.03";
 
     /** Performs setup if necessary. */
     static void setupIfNeeded(final Activity activity, final Runnable whenDone) {


### PR DESCRIPTION
Did not test it, but seems to be a neccessary change.