### PR TITLE
Rebase on upstream Termux

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,7 @@ android {
         manifestPlaceholders.TERMUX_TASKER_APP_NAME = "Termux:Tasker"
         manifestPlaceholders.TERMUX_WIDGET_APP_NAME = "Termux:Widget"
 
+        /* NIX-ON-DROID: Unused
         externalNativeBuild {
             ndkBuild {
                 cFlags "-std=c11", "-Wall", "-Wextra", "-Werror", "-Os", "-fno-stack-protector", "-Wl,--gc-sections"
@@ -73,6 +74,7 @@ android {
                 universalApk true
             }
         }
+        */
     }
 
     signingConfigs {
@@ -104,11 +106,13 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    /* NIX-ON-DROID: Unused
     externalNativeBuild {
         ndkBuild {
             path "src/main/cpp/Android.mk"
         }
     }
+    */
 
     lintOptions {
         disable 'ProtectedPermissions'
@@ -210,6 +214,7 @@ clean {
     }
 }
 
+/* NIX-ON-DROID: Unused
 task downloadBootstraps() {
     doLast {
         def packageVariant = project.ext.packageVariant
@@ -236,3 +241,4 @@ afterEvaluate {
         variant.javaCompileProvider.get().dependsOn(downloadBootstraps)
     }
 }
+*/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ android {
 
     defaultConfig {
         applicationId "com.termux"
-        applicationIdSuffix ".nix"
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
         versionCode 118
@@ -76,6 +75,18 @@ android {
             }
         }
         */
+    }
+
+    // NIX-ON-DROID: Downstream version
+    defaultConfig {
+        def nixOnDroidMajor = 0
+        def nixOnDroidMinor = 3
+        def nixOnDroidRev = 0
+
+        applicationIdSuffix ".nix"
+        versionNameSuffix "_v${nixOnDroidMajor}.${nixOnDroidMinor}.${nixOnDroidRev}_nix"
+        versionCode android.defaultConfig.versionCode * 1000 + \
+            nixOnDroidMajor * 100 + nixOnDroidMinor * 10 + nixOnDroidRev
     }
 
     signingConfigs {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ android {
 
     defaultConfig {
         applicationId "com.termux"
+        applicationIdSuffix ".nix"
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
         versionCode 118
@@ -49,8 +50,8 @@ android {
 
         buildConfigField "String", "TERMUX_PACKAGE_VARIANT", "\"" + project.ext.packageVariant + "\"" // Used by TermuxApplication class
 
-        manifestPlaceholders.TERMUX_PACKAGE_NAME = "com.termux"
-        manifestPlaceholders.TERMUX_APP_NAME = "Termux"
+        manifestPlaceholders.TERMUX_PACKAGE_NAME = "com.termux.nix"
+        manifestPlaceholders.TERMUX_APP_NAME = "Nix"
         manifestPlaceholders.TERMUX_API_APP_NAME = "Termux:API"
         manifestPlaceholders.TERMUX_BOOT_APP_NAME = "Termux:Boot"
         manifestPlaceholders.TERMUX_FLOAT_APP_NAME = "Termux:Float"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -158,6 +158,7 @@
             </intent-filter>
         </activity-alias>
 
+        <!--
         <provider
             android:name=".filepicker.TermuxDocumentsProvider"
             android:authorities="${TERMUX_PACKAGE_NAME}.documents"
@@ -175,6 +176,7 @@
             android:exported="true"
             android:grantUriPermissions="true"
             android:permission="${TERMUX_PACKAGE_NAME}.permission.RUN_COMMAND" />
+        -->
 
 
         <receiver

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -4,11 +4,14 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Environment;
+import android.os.SystemClock;
 import android.system.Os;
 import android.util.Pair;
 import android.view.WindowManager;
+import android.widget.EditText;
 
 import com.termux.R;
 import com.termux.shared.file.FileUtils;
@@ -28,7 +31,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -48,7 +54,7 @@ import static com.termux.shared.termux.TermuxConstants.TERMUX_STAGING_PREFIX_DIR
  * <p/>
  * (3) A staging directory, $STAGING_PREFIX, is cleared if left over from broken installation below.
  * <p/>
- * (4) The zip file is loaded from a shared library.
+ * (4) The architecture is determined and an appropriate bootstrap zip url is determined in {@link #determineZipUrl()}.
  * <p/>
  * (5) The zip, containing entries relative to the $PREFIX, is is downloaded and extracted by a zip input stream
  * continuously encountering zip file entries:
@@ -60,6 +66,7 @@ import static com.termux.shared.termux.TermuxConstants.TERMUX_STAGING_PREFIX_DIR
 final class TermuxInstaller {
 
     private static final String LOG_TAG = "TermuxInstaller";
+    static String defaultBootstrapURL = "https://nix-on-droid.unboiled.info/bootstrap";
 
     /** Performs bootstrap setup if necessary. */
     static void setupBootstrapIfNeeded(final Activity activity, final Runnable whenDone) {
@@ -114,6 +121,29 @@ final class TermuxInstaller {
             Logger.logInfo(LOG_TAG, "The termux prefix directory \"" + TERMUX_PREFIX_DIR_PATH + "\" does not exist but another file exists at its destination.");
         }
 
+        final EditText taskEditText = new EditText(activity);
+        String archName = determineTermuxArchName();
+        taskEditText.setHint(defaultBootstrapURL);
+        taskEditText.setText(defaultBootstrapURL);
+
+        AlertDialog dialog = new AlertDialog.Builder(activity)
+            .setTitle("Bootstrap zipball location")
+            .setMessage("Enter the URL of a directory containing bootstrap-" + archName + ".zip")
+            .setView(taskEditText)
+            .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    String bootstrapURL = String.valueOf(taskEditText.getText());
+                    restOfSetupIfNeeded(activity, whenDone, bootstrapURL);
+                }
+            })
+            .create();
+
+        dialog.show();
+    }
+
+    static void restOfSetupIfNeeded(final Activity activity, final Runnable whenDone, String bootstrapURL) {
+
         final ProgressDialog progress = ProgressDialog.show(activity, null, activity.getString(R.string.bootstrap_installer_body), true, false);
         new Thread() {
             @Override
@@ -156,8 +186,8 @@ final class TermuxInstaller {
                     final byte[] buffer = new byte[8096];
                     final List<Pair<String, String>> symlinks = new ArrayList<>(50);
 
-                    final byte[] zipBytes = loadZipBytes();
-                    try (ZipInputStream zipInput = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+                    final URL zipUrl = determineZipUrl(bootstrapURL);
+                    try (ZipInputStream zipInput = new ZipInputStream(zipUrl.openStream())) {
                         ZipEntry zipEntry;
                         while ((zipEntry = zipInput.getNextEntry()) != null) {
                             if (zipEntry.getName().equals("SYMLINKS.txt")) {
@@ -375,12 +405,42 @@ final class TermuxInstaller {
         return FileUtils.createDirectoryFile(directory.getAbsolutePath());
     }
 
+    // NIX-ON-DROID: Unused
+    @SuppressWarnings("unused")
     public static byte[] loadZipBytes() {
         // Only load the shared library when necessary to save memory usage.
         System.loadLibrary("termux-bootstrap");
         return getZip();
     }
 
+    // NIX-ON-DROID: Unused
+    @SuppressWarnings("unused")
     public static native byte[] getZip();
+
+    /** Get bootstrap zip url for this systems cpu architecture. */
+    private static URL determineZipUrl(String bootstrapURL) throws MalformedURLException {
+        String archName = determineTermuxArchName();
+        return new URL(bootstrapURL + "/bootstrap-" + archName + ".zip");
+    }
+
+    private static String determineTermuxArchName() {
+        // Note that we cannot use System.getProperty("os.arch") since that may give e.g. "aarch64"
+        // while a 64-bit runtime may not be installed (like on the Samsung Galaxy S5 Neo).
+        // Instead we search through the supported abi:s on the device, see:
+        // http://developer.android.com/ndk/guides/abis.html
+        // Note that we search for abi:s in preferred order (the ordering of the
+        // Build.SUPPORTED_ABIS list) to avoid e.g. installing arm on an x86 system where arm
+        // emulation is available.
+        for (String androidArch : Build.SUPPORTED_ABIS) {
+            switch (androidArch) {
+                case "arm64-v8a": return "aarch64";
+                case "armeabi-v7a": return "arm";
+                case "x86_64": return "x86_64";
+                case "x86": return "i686";
+            }
+        }
+        throw new RuntimeException("Unable to determine arch from Build.SUPPORTED_ABIS =  " +
+            Arrays.toString(Build.SUPPORTED_ABIS));
+    }
 
 }

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -185,6 +185,7 @@ final class TermuxInstaller {
 
                     final byte[] buffer = new byte[8096];
                     final List<Pair<String, String>> symlinks = new ArrayList<>(50);
+                    final List<String> executables = new ArrayList<>(128);
 
                     final URL zipUrl = determineZipUrl(bootstrapURL);
                     try (ZipInputStream zipInput = new ZipInputStream(zipUrl.openStream())) {
@@ -206,6 +207,12 @@ final class TermuxInstaller {
                                         showBootstrapErrorDialog(activity, whenDone, Error.getErrorMarkdownString(error));
                                         return;
                                     }
+                                }
+                            } else if (zipEntry.getName().equals("EXECUTABLES.txt")) {
+                                BufferedReader executablesReader = new BufferedReader(new InputStreamReader(zipInput));
+                                String line;
+                                while ((line = executablesReader.readLine()) != null) {
+                                    executables.add(line);
                                 }
                             } else {
                                 String zipEntryName = zipEntry.getName();
@@ -232,6 +239,19 @@ final class TermuxInstaller {
                                 }
                             }
                         }
+                    }
+
+                    if (!executables.isEmpty()) {
+                        for (String executable : executables) {
+                            //noinspection OctalInteger
+                            try {
+                                Os.chmod(TERMUX_STAGING_PREFIX_DIR + "/" + executable, 0700);
+                            } catch (Throwable t) {
+                                Logger.logError(LOG_TAG, "EXECUTABLES error: " + TERMUX_STAGING_PREFIX_DIR + "/" + executable + t);
+                            }
+                        }
+                    } else {
+                        throw new RuntimeException("Installer: no EXECUTABLES.txt found while extracting environment archive.");
                     }
 
                     if (symlinks.isEmpty())

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Environment;
-import android.os.SystemClock;
 import android.system.Os;
 import android.util.Pair;
 import android.view.WindowManager;
@@ -27,7 +26,6 @@ import com.termux.shared.termux.TermuxUtils;
 import com.termux.shared.termux.shell.command.environment.TermuxShellEnvironment;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
@@ -424,18 +422,6 @@ final class TermuxInstaller {
     private static Error ensureDirectoryExists(File directory) {
         return FileUtils.createDirectoryFile(directory.getAbsolutePath());
     }
-
-    // NIX-ON-DROID: Unused
-    @SuppressWarnings("unused")
-    public static byte[] loadZipBytes() {
-        // Only load the shared library when necessary to save memory usage.
-        System.loadLibrary("termux-bootstrap");
-        return getZip();
-    }
-
-    // NIX-ON-DROID: Unused
-    @SuppressWarnings("unused")
-    public static native byte[] getZip();
 
     /** Get bootstrap zip url for this systems cpu architecture. */
     private static URL determineZipUrl(String bootstrapURL) throws MalformedURLException {

--- a/app/src/main/java/com/termux/app/TermuxInstaller.java
+++ b/app/src/main/java/com/termux/app/TermuxInstaller.java
@@ -66,7 +66,7 @@ import static com.termux.shared.termux.TermuxConstants.TERMUX_STAGING_PREFIX_DIR
 final class TermuxInstaller {
 
     private static final String LOG_TAG = "TermuxInstaller";
-    static String defaultBootstrapURL = "https://nix-on-droid.unboiled.info/bootstrap";
+    static String defaultBootstrapURL = "https://nix-on-droid.unboiled.info/bootstrap-release-22.05";
 
     /** Performs bootstrap setup if necessary. */
     static void setupBootstrapIfNeeded(final Activity activity, final Runnable whenDone) {

--- a/app/src/main/res/drawable/ic_foreground_nix.xml
+++ b/app/src/main/res/drawable/ic_foreground_nix.xml
@@ -1,0 +1,70 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="m49.535,70.669 l24.661,0.001 -2.787,5.055 -6.615,-0.019 3.285,5.866 -1.409,2.498 -2.878,0.003 -4.672,-8.352 -6.729,-0.014z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M48.589,53.176 L36.258,75.059 33.379,70.058 36.702,64.198 30.102,64.18 28.695,61.681 30.132,59.125 39.526,59.156 42.903,53.192Z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M63.889,61.081 L51.559,39.197 57.226,39.142 60.517,45.022 63.832,39.174 66.648,39.175 68.09,41.727 63.367,50.049 66.719,56.027Z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M44.139,62.191 L56.469,84.074 50.802,84.129 47.511,78.249 44.196,84.097 41.38,84.096 39.938,81.544 44.661,73.222 41.309,67.244Z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M58.442,52.549L33.783,52.551 36.568,47.495 43.185,47.516 39.898,41.652 41.306,39.153 44.187,39.148 48.859,47.501 55.587,47.515Z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M59.414,70.093L71.741,48.21 74.622,53.21 71.295,59.071 77.895,59.087 79.303,61.586 77.868,64.144 68.471,64.114 65.095,70.077Z"
+      android:strokeAlpha="1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.05438897"
+      android:fillColor="#ffffff"
+      android:strokeColor="#00000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="1"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="m60.019,27.682 l2.035,-3.142c0.131,-0.198 0.073,-0.469 -0.127,-0.598 -0.198,-0.131 -0.469,-0.077 -0.598,0.127L59.219,27.32C57.636,26.671 55.867,26.307 54,26.307c-1.869,0 -3.634,0.364 -5.22,1.013L46.673,24.069C46.544,23.866 46.271,23.811 46.071,23.942 45.871,24.071 45.813,24.342 45.944,24.54L47.981,27.682C44.309,29.482 41.832,32.875 41.832,36.766c0,0.239 0.015,0.475 0.036,0.708l24.267,0c0.021,-0.234 0.034,-0.469 0.034,-0.708 0,-3.891 -2.478,-7.284 -6.149,-9.084zM48.374,33.308c-0.645,0 -1.168,-0.52 -1.168,-1.166 0,-0.647 0.523,-1.164 1.168,-1.164 0.649,0 1.168,0.518 1.168,1.164 0,0.647 -0.523,1.166 -1.168,1.166zM59.624,33.308c-0.645,0 -1.168,-0.52 -1.168,-1.166 0,-0.647 0.523,-1.164 1.168,-1.164 0.647,0 1.166,0.518 1.166,1.164 0,0.647 -0.52,1.166 -1.166,1.166z"
+      android:strokeWidth="0.02729056"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@android:color/black"/>
-    <foreground android:drawable="@drawable/ic_foreground"/>
+    <foreground android:drawable="@drawable/ic_foreground_nix"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@android:color/black"/>
-    <foreground android:drawable="@drawable/ic_foreground"/>
+    <foreground android:drawable="@drawable/ic_foreground_nix"/>
 </adaptive-icon>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE resources [
     <!ENTITY TERMUX_PACKAGE_NAME "com.termux">
-    <!ENTITY TERMUX_APP_NAME "Termux">
+    <!ENTITY TERMUX_APP_NAME "Nix">
     <!ENTITY TERMUX_API_APP_NAME "Termux:API">
     <!ENTITY TERMUX_BOOT_APP_NAME "Termux:Boot">
     <!ENTITY TERMUX_FLOAT_APP_NAME "Termux:Float">

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -18,7 +18,7 @@
         tools:targetApi="n_mr1">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.termux"
+            android:targetPackage="com.termux.nix"
             android:targetClass="com.termux.app.TermuxActivity"
             android:name="android.shortcut.conversation"/>
     </shortcut>
@@ -31,7 +31,7 @@
         tools:targetApi="n_mr1">
         <intent
             android:action="android.intent.action.RUN"
-            android:targetPackage="com.termux"
+            android:targetPackage="com.termux.nix"
             android:targetClass="com.termux.app.TermuxActivity"
             android:name="android.shortcut.conversation">
             <extra android:name="com.termux.app.failsafe_session" android:value="true"/>
@@ -46,7 +46,7 @@
         tools:targetApi="n_mr1">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.termux"
+            android:targetPackage="com.termux.nix"
             android:targetClass="com.termux.app.activities.SettingsActivity"
             android:name="android.shortcut.conversation"/>
     </shortcut>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -34,7 +34,7 @@
             android:targetPackage="com.termux.nix"
             android:targetClass="com.termux.app.TermuxActivity"
             android:name="android.shortcut.conversation">
-            <extra android:name="com.termux.app.failsafe_session" android:value="true"/>
+            <extra android:name="com.termux.nix.app.failsafe_session" android:value="true"/>
         </intent>
     </shortcut>
 

--- a/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
+++ b/termux-shared/src/main/java/com/termux/shared/termux/TermuxConstants.java
@@ -342,9 +342,9 @@ public final class TermuxConstants {
      */
 
     /** Termux app name */
-    public static final String TERMUX_APP_NAME = "Termux"; // Default: "Termux"
+    public static final String TERMUX_APP_NAME = "Nix"; // Default: "Termux"
     /** Termux package name */
-    public static final String TERMUX_PACKAGE_NAME = "com.termux"; // Default: "com.termux"
+    public static final String TERMUX_PACKAGE_NAME = "com.termux.nix"; // Default: "com.termux"
     /** Termux Github repo name */
     public static final String TERMUX_GITHUB_REPO_NAME = "termux-app"; // Default: "termux-app"
     /** Termux Github repo url */


### PR DESCRIPTION
I manually applied the Nix-on-Droid-specific bits on top of the upstream Termux app. The diff here is too large - See [the diff against upstream Termux](https://github.com/termux/termux-app/compare/master...zhaofengli:nix-on-droid-app:big-rebase). I took some creative liberties and tried to keep the diff as minimal as possible.

Unfortunately, merging the addons (no longer paid since the Play Store version got discontinued) seems be a messy task.

The app seems kind of usable, with new features like shortcuts (no more separate launcher icon for the failsafe mode). Launching multiple sessions seem to work as well:

<details>

![Screenshot_20220913-014602_One UI Home](https://user-images.githubusercontent.com/2189609/189845205-f9b14605-3d78-43fd-a8ee-62f0103755f8.jpg)
</details>

Ref: https://github.com/t184256/nix-on-droid/issues/168#issuecomment-1025217178